### PR TITLE
Minor changes for the WGLC branch

### DIFF
--- a/draft-ietf-cbor-cddl-control.md
+++ b/draft-ietf-cbor-cddl-control.md
@@ -55,7 +55,7 @@ not make it into RFC 8610: `.plus`, `.cat` and `.det` for the construction of co
 Introduction        {#intro}
 ============
 
-The Concise Data Definition Language (CDDL), standardized in RFC 8610,
+The Concise Data Definition Language (CDDL), standardized in {{-cddl}},
 provides "control operators" as its main language extension point.
 
 The present document defines a number of control operators that did

--- a/draft-ietf-cbor-cddl-control.md
+++ b/draft-ietf-cbor-cddl-control.md
@@ -86,7 +86,7 @@ CDDL as defined in {{-cddl}} does not have any mechanisms to compute
 literals.  As an 80 % solution, this specification adds three control
 operators: `.plus` for numeric addition, `.cat` for string
 concatenation, and `.det` for string concatenation with dedenting of
-the right hand side (controller).
+both sides (target and controller).
 
 
 Numeric Addition


### PR DESCRIPTION
* Reference CDDL by-link on first mention outside abstract (probably from shared ancestry with abstract)
* computed literals intro: fix missing ambidexterous det (probably missed when making det work on both)